### PR TITLE
Added Carthage support and upgraded to Swift 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ styledLabel.text = "This is a new string"
 
 # Installation
 
+### Cocoapods
+
 1. Add this line to your Podfile:
 
 ```
@@ -43,6 +45,25 @@ pod "StyledText"
 
 2. Run a `pod install`
 3. You're all set!
+
+### Carthage
+
+[Carthage](https://github.com/Carthage/Carthage) is a decentralized dependency manager that builds your dependencies and provides you with binary frameworks.
+
+You can install Carthage with [Homebrew](http://brew.sh/) using the following command:
+
+```bash
+$ brew update
+$ brew install carthage
+```
+
+To integrate StyledText into your Xcode project using Carthage, specify it in your `Cartfile`:
+
+```ogdl
+github "blueapron/styled-text"
+```
+
+Run `carthage update` to build the framework and drag the built `StyledText.framework` into your Xcode project.
 
 # How to Use
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-#  <img src='https://user-images.githubusercontent.com/4182788/29837864-703557a2-8cc7-11e7-9411-89def22ef0f3.png' width=100 align='center'>   StyledText   [![BuddyBuild](https://dashboard.buddybuild.com/api/statusImage?appID=599b31b30b95740001249898&branch=master&build=latest)](https://dashboard.buddybuild.com/apps/599b31b30b95740001249898/build/latest?branch=master) 
+#  <img src='https://user-images.githubusercontent.com/4182788/29837864-703557a2-8cc7-11e7-9411-89def22ef0f3.png' width=100 align='center'>   StyledText   [![BuddyBuild](https://dashboard.buddybuild.com/api/statusImage?appID=599b31b30b95740001249898&branch=master&build=latest)](https://dashboard.buddybuild.com/apps/599b31b30b95740001249898/build/latest?branch=master) [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
+
 StyledText is a library that simplifies styling dynamic text in iOS applications.  Instead of having to use attributed strings every time you need to update text, you can declaratively set a text style on your labels.  When the text of the label is updated, the label uses the preset style.
 
 <p align='center'>

--- a/StyledText.xcodeproj/project.pbxproj
+++ b/StyledText.xcodeproj/project.pbxproj
@@ -1,0 +1,356 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 48;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		BFD737691F8FC67F00ED3704 /* StyledText.h in Headers */ = {isa = PBXBuildFile; fileRef = BFD737671F8FC67F00ED3704 /* StyledText.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BFD737781F8FC72600ED3704 /* WeakArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD737701F8FC71C00ED3704 /* WeakArray.swift */; };
+		BFD737791F8FC72600ED3704 /* StyledButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD737711F8FC71C00ED3704 /* StyledButton.swift */; };
+		BFD7377A1F8FC72600ED3704 /* TextStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD737731F8FC71C00ED3704 /* TextStyle.swift */; };
+		BFD7377B1F8FC72600ED3704 /* DynamicTypeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD737741F8FC71C00ED3704 /* DynamicTypeController.swift */; };
+		BFD7377C1F8FC72600ED3704 /* StyledLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD737751F8FC71C00ED3704 /* StyledLabel.swift */; };
+		BFD7377D1F8FC72600ED3704 /* StyledText.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD737761F8FC71C00ED3704 /* StyledText.swift */; };
+		BFD7377E1F8FC72600ED3704 /* StyledTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD737771F8FC71C00ED3704 /* StyledTextView.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		BFD737641F8FC67F00ED3704 /* StyledText.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StyledText.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		BFD737671F8FC67F00ED3704 /* StyledText.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyledText.h; sourceTree = "<group>"; };
+		BFD737681F8FC67F00ED3704 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		BFD737701F8FC71C00ED3704 /* WeakArray.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeakArray.swift; sourceTree = "<group>"; };
+		BFD737711F8FC71C00ED3704 /* StyledButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyledButton.swift; sourceTree = "<group>"; };
+		BFD737731F8FC71C00ED3704 /* TextStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextStyle.swift; sourceTree = "<group>"; };
+		BFD737741F8FC71C00ED3704 /* DynamicTypeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicTypeController.swift; sourceTree = "<group>"; };
+		BFD737751F8FC71C00ED3704 /* StyledLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyledLabel.swift; sourceTree = "<group>"; };
+		BFD737761F8FC71C00ED3704 /* StyledText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyledText.swift; sourceTree = "<group>"; };
+		BFD737771F8FC71C00ED3704 /* StyledTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyledTextView.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		BFD737601F8FC67F00ED3704 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		BFD7375A1F8FC67F00ED3704 = {
+			isa = PBXGroup;
+			children = (
+				BFD737661F8FC67F00ED3704 /* StyledText */,
+				BFD737651F8FC67F00ED3704 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		BFD737651F8FC67F00ED3704 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				BFD737641F8FC67F00ED3704 /* StyledText.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		BFD737661F8FC67F00ED3704 /* StyledText */ = {
+			isa = PBXGroup;
+			children = (
+				BFD7376F1F8FC71C00ED3704 /* Classes */,
+				BFD737671F8FC67F00ED3704 /* StyledText.h */,
+				BFD737681F8FC67F00ED3704 /* Info.plist */,
+			);
+			path = StyledText;
+			sourceTree = "<group>";
+		};
+		BFD7376F1F8FC71C00ED3704 /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				BFD737701F8FC71C00ED3704 /* WeakArray.swift */,
+				BFD737711F8FC71C00ED3704 /* StyledButton.swift */,
+				BFD737731F8FC71C00ED3704 /* TextStyle.swift */,
+				BFD737741F8FC71C00ED3704 /* DynamicTypeController.swift */,
+				BFD737751F8FC71C00ED3704 /* StyledLabel.swift */,
+				BFD737761F8FC71C00ED3704 /* StyledText.swift */,
+				BFD737771F8FC71C00ED3704 /* StyledTextView.swift */,
+			);
+			path = Classes;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		BFD737611F8FC67F00ED3704 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BFD737691F8FC67F00ED3704 /* StyledText.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		BFD737631F8FC67F00ED3704 /* StyledText */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BFD7376C1F8FC67F00ED3704 /* Build configuration list for PBXNativeTarget "StyledText" */;
+			buildPhases = (
+				BFD7375F1F8FC67F00ED3704 /* Sources */,
+				BFD737601F8FC67F00ED3704 /* Frameworks */,
+				BFD737611F8FC67F00ED3704 /* Headers */,
+				BFD737621F8FC67F00ED3704 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = StyledText;
+			productName = StyledText;
+			productReference = BFD737641F8FC67F00ED3704 /* StyledText.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		BFD7375B1F8FC67F00ED3704 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0900;
+				TargetAttributes = {
+					BFD737631F8FC67F00ED3704 = {
+						CreatedOnToolsVersion = 9.0;
+						ProvisioningStyle = Manual;
+					};
+				};
+			};
+			buildConfigurationList = BFD7375E1F8FC67F00ED3704 /* Build configuration list for PBXProject "StyledText" */;
+			compatibilityVersion = "Xcode 8.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = BFD7375A1F8FC67F00ED3704;
+			productRefGroup = BFD737651F8FC67F00ED3704 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				BFD737631F8FC67F00ED3704 /* StyledText */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		BFD737621F8FC67F00ED3704 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		BFD7375F1F8FC67F00ED3704 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BFD7377A1F8FC72600ED3704 /* TextStyle.swift in Sources */,
+				BFD7377B1F8FC72600ED3704 /* DynamicTypeController.swift in Sources */,
+				BFD737791F8FC72600ED3704 /* StyledButton.swift in Sources */,
+				BFD7377D1F8FC72600ED3704 /* StyledText.swift in Sources */,
+				BFD737781F8FC72600ED3704 /* WeakArray.swift in Sources */,
+				BFD7377E1F8FC72600ED3704 /* StyledTextView.swift in Sources */,
+				BFD7377C1F8FC72600ED3704 /* StyledLabel.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		BFD7376A1F8FC67F00ED3704 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		BFD7376B1F8FC67F00ED3704 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		BFD7376D1F8FC67F00ED3704 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Manual;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = StyledText/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = blueapron.StyledText;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		BFD7376E1F8FC67F00ED3704 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Manual;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = StyledText/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = blueapron.StyledText;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		BFD7375E1F8FC67F00ED3704 /* Build configuration list for PBXProject "StyledText" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BFD7376A1F8FC67F00ED3704 /* Debug */,
+				BFD7376B1F8FC67F00ED3704 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		BFD7376C1F8FC67F00ED3704 /* Build configuration list for PBXNativeTarget "StyledText" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BFD7376D1F8FC67F00ED3704 /* Debug */,
+				BFD7376E1F8FC67F00ED3704 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = BFD7375B1F8FC67F00ED3704 /* Project object */;
+}

--- a/StyledText.xcodeproj/project.pbxproj
+++ b/StyledText.xcodeproj/project.pbxproj
@@ -297,6 +297,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = StyledText/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = blueapron.StyledText;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -319,6 +320,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = StyledText/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = blueapron.StyledText;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";

--- a/StyledText.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/StyledText.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:StyledText.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/StyledText.xcodeproj/xcshareddata/xcschemes/StyledText.xcscheme
+++ b/StyledText.xcodeproj/xcshareddata/xcschemes/StyledText.xcscheme
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0900"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BFD737631F8FC67F00ED3704"
+               BuildableName = "StyledText.framework"
+               BlueprintName = "StyledText"
+               ReferencedContainer = "container:StyledText.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BFD737631F8FC67F00ED3704"
+            BuildableName = "StyledText.framework"
+            BlueprintName = "StyledText"
+            ReferencedContainer = "container:StyledText.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BFD737631F8FC67F00ED3704"
+            BuildableName = "StyledText.framework"
+            BlueprintName = "StyledText"
+            ReferencedContainer = "container:StyledText.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/StyledText/Classes/StyledText.swift
+++ b/StyledText/Classes/StyledText.swift
@@ -33,7 +33,7 @@ public struct StyledAttributedString: StyledText {
             return attributedString
         }
 
-        func enumerator(attributes: [String: Any], range: NSRange, stop: UnsafeMutablePointer<ObjCBool>) {
+        func enumerator(attributes: [NSAttributedStringKey: Any], range: NSRange, stop: UnsafeMutablePointer<ObjCBool>) {
             var attributesToAdd = style.attributes
             // choosing existing string attributes if they exist over our style attributes [RH]
             attributes.forEach { (key, _) in

--- a/StyledText/Classes/TextStyle.swift
+++ b/StyledText/Classes/TextStyle.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 public protocol TextStyleDefaultsGenerator {
     static func defaultKern(for font: UIFont) -> CGFloat?
@@ -63,8 +64,8 @@ public struct TextStyle {
         self.dynamicTypeController = controller
     }
 
-    public var attributes: [String: Any] {
-        var attributes: [String: Any] = [:]
+    public var attributes: [NSAttributedStringKey: Any] {
+        var attributes: [NSAttributedStringKey: Any] = [:]
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.setParagraphStyle(.default)
 
@@ -78,19 +79,19 @@ public struct TextStyle {
             scaledFont = dynamicTypeController.adjustFontForDynamicSize(font: font, supportAccessibiltySizes: true)
         }
 
-        attributes[NSFontAttributeName] = scaledFont
-        attributes[NSForegroundColorAttributeName] = color
+        attributes[.font] = scaledFont
+        attributes[.foregroundColor] = color
 
         if let lineSpacing = lineSpacing { paragraphStyle.lineSpacing = lineSpacing }
         if let lineHeightMultiple = lineHeightMultiple {
             let adjustedLineHeightMultiple = lineHeightMultiple * (font.pointSize / font.lineHeight)
             paragraphStyle.lineHeightMultiple = adjustedLineHeightMultiple
         }
-        if let kern = kern { attributes[NSKernAttributeName] = kern }
+        if let kern = kern { attributes[.kern] = kern }
         if let alignment = alignment { paragraphStyle.alignment = alignment }
         if let lineBreakMode = lineBreakMode { paragraphStyle.lineBreakMode = lineBreakMode }
 
-        attributes[NSParagraphStyleAttributeName] = paragraphStyle
+        attributes[.paragraphStyle] = paragraphStyle
 
         return attributes
     }

--- a/StyledText/Info.plist
+++ b/StyledText/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/StyledText/StyledText.h
+++ b/StyledText/StyledText.h
@@ -1,0 +1,4 @@
+#import <Foundation/Foundation.h>
+
+FOUNDATION_EXPORT double StyledTextVersionNumber;
+FOUNDATION_EXPORT const unsigned char StyledTextVersionString[];


### PR DESCRIPTION
## Description

- Upgraded to Swift 4.
- Added an Xcode project with a shared build scheme so Carthage is able to build a dynamic framework.
- Updated README.md to reflect new installation option.
- Tested everything from my personal fork.

## After merge

Please tag this as a stable release on GitHub so Carthage will be able to find it. Carthage determines which versions of framework are available by searching through the tags published on the repository, and trying to interpret each tag name as a semantic version. For example, in the tag v1.2, the semantic version is 1.2.0.